### PR TITLE
Updated dependencies to use ~ convention, updated deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "test": "nodeunit test.js"
   },
-  "repository": "git://github.com/andris9/encoding.git",
+  "repository": "https://github.com/andris9/encoding.git",
   "author": "Andris Reinman",
   "license": "MIT",
   "dependencies":{
-    "iconv-lite": "0.2.7"
+    "iconv-lite": "~0.2.11"
   },
   "devDependencies":{
-    "nodeunit": "*"
+    "nodeunit": "~0.8.1"
   }
 }


### PR DESCRIPTION
Specifying `0.2.7` means only use that, specifying `~0.2.7` means `>= 0.2.7 < 0.3` (so allow bugfixes but not any b/c breaks).

This will allow us to get bugfixes in the iconv-lite dep without having to keep republishing encoding.

I've also done the same for nodeunit, which means that if nodeunit 0.9 or 1.0 comes out which breaks anything, the tests for this will still run as it will use a version that it is compatible with.

I've also updated the repository field to use https instead of git to allow support for cloning when behind restricted proxies.
