### PR TITLE
write errors to STDERR instead of STDOUT

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -45,11 +45,11 @@ function convert(str, to, from, useLite) {
             try {
                 result = convertIconv(str, to, from);
             } catch (E) {
-                console.log(E);
+                console.error(E);
                 try {
                     result = convertIconvLite(str, to, from);
                 } catch (E) {
-                    console.log(E);
+                    console.error(E);
                     result = str;
                 }
             }
@@ -57,7 +57,7 @@ function convert(str, to, from, useLite) {
             try {
                 result = convertIconvLite(str, to, from);
             } catch (E) {
-                console.log(E);
+                console.error(E);
                 result = str;
             }
         }


### PR DESCRIPTION
I ran into an issue where:
- I was parsing an html email with an invalid charset (`<meta http-equiv="Content-Type" content="text/html; charset=3DUTF-8">`), which caused [_detectHTMLCharset](https://github.com/andris9/mailparser/blob/master/lib/mailparser.js#L1387) to return `3DUTF-8` as the detected charset
- This caused iconv to throw inside [convert](https://github.com/andris9/encoding/blob/master/lib/encoding.js#L26) which writes the error to STDOUT
- This means [mbox-stream](https://www.npmjs.org/package/mbox-stream) writes invalid output to STDOUT. It is supposed to only write JSON to STDOUT but currently the `encoding` module is violating the UNIX rule of silence by writing directly to STDOUT. This addresses the issue by writing to STDERR instead.

A more ideal solution would be for the encoding module to pass the error back rather than simply printing it directly, but this is a quicker duct-tape style fix
