### PR TITLE
Ignore iconv via browser field instead of workaround

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,15 +1,7 @@
 'use strict';
 
 var iconvLite = require('iconv-lite');
-var Iconv;
-
-try {
-    // this is to fool browserify so it doesn't try (in vain) to install iconv.
-    var iconv_package = 'iconv';
-    Iconv = require(iconv_package).Iconv;
-} catch (E) {
-    // node-iconv not present
-}
+var Iconv = require('iconv').Iconv;
 
 // Expose to the world
 module.exports.convert = convert;

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "devDependencies": {
     "nodeunit": "~0.8.1"
+  },
+  "browser": {
+    "iconv": false
   }
 }


### PR DESCRIPTION
The workaround for browserify can be easily replaced by defining the `browser` field in `package.json`, as stated in the [specification](https://gist.github.com/defunctzombie/4339901#ignore-a-module).

This will also make webpack happy since there are no dynamic dependencies anymore.

Refs: https://github.com/webpack/webpack/issues/918#issuecomment-98647987